### PR TITLE
[BREAKING] drop node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
+
+sudo: false
+dist: trusty
 
 cache:
   yarn: true
-  directories:
-    - $HOME/.yarn-cache
-
-before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH=$HOME
 
 install:
   - yarn install --no-lockfile

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/dockyard/ember-cli-deploy-compress",
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "author": "Miguel Camba",
   "license": "MIT",


### PR DESCRIPTION
Should unblock the other (currently failing) PRs, see https://github.com/DockYard/ember-cli-deploy-compress/pull/13#issuecomment-457737846