### PR TITLE
feat: delay browser target access

### DIFF
--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -7,6 +7,9 @@ const fs  = require('fs');
 const path  = require('path');
 const rimraf  = RSVP.denodeify(require('rimraf'));
 
+const BROTLI_SUPPORTED = ['last 2 Chrome versions'];
+const BROTLI_NOT_SUPPORTED = ['ie 11'];
+
 describe('compress plugin', function() {
   let subject, mockUi, config;
 
@@ -166,6 +169,9 @@ describe('compress plugin', function() {
           },
           dependencies() {
             return { 'node-zopfli-es': '1.0.1' };
+          },
+          targets: {
+            browsers: null
           }
         },
         config: {
@@ -234,7 +240,7 @@ describe('compress plugin', function() {
 
       describe('When brotli compression is supported in all browsers', function () {
         beforeEach(function() {
-          plugin.canUseBrotli = true;
+          plugin.project.targets.browsers = BROTLI_SUPPORTED;
           plugin.configure();
         });
 
@@ -281,7 +287,7 @@ describe('compress plugin', function() {
 
       describe('When brotli compression is not supported in all browsers', function () {
         beforeEach(function () {
-          plugin.canUseBrotli = false;
+          plugin.project.targets.browsers = BROTLI_NOT_SUPPORTED;
         });
 
         it('gzips the matching files which are not ignored', function() {
@@ -321,7 +327,7 @@ describe('compress plugin', function() {
 
       describe('When brotli compression is supported in all browsers', function () {
         beforeEach(function () {
-          plugin.canUseBrotli = true;
+          plugin.project.targets.browsers = BROTLI_SUPPORTED;
           plugin.configure();
         });
 
@@ -376,7 +382,7 @@ describe('compress plugin', function() {
 
       describe('When brotli compression is not supported in all browsers', function () {
         beforeEach(function () {
-          plugin.canUseBrotli = false;
+          plugin.project.targets.browsers = BROTLI_NOT_SUPPORTED;
         });
 
         it('gzips the matching files with .gz suffix', function() {
@@ -408,9 +414,9 @@ describe('compress plugin', function() {
         });
       });
 
-      describe('When brotli compression is not supported in all browsers', function () {
+      describe('When brotli compression is supported in all browsers', function () {
         beforeEach(function () {
-          plugin.canUseBrotli = true;
+          plugin.project.targets.browsers = BROTLI_SUPPORTED;
         });
 
         it('gzips the matching files with .gz suffix', function() {
@@ -459,7 +465,7 @@ describe('compress plugin', function() {
 
       describe('When brotli compression is supported in all browsers', function () {
         beforeEach(function() {
-          plugin.canUseBrotli = true;
+          plugin.project.targets.browsers = BROTLI_SUPPORTED;
           plugin.configure();
         });
 


### PR DESCRIPTION
Currently `this.project.targets` is accessed as soon as the plugin is instantiated, which is during the plugin initialization phase of ember-cli-deploy, specifically in [`plugin-registry.js`](https://github.com/ember-cli-deploy/ember-cli-deploy/blob/bd7b08d1084921193042787ce27570a00dafd5aa/lib/models/plugin-registry.js#L219-L233). This happens [_before_ plugins are ordered](https://github.com/ember-cli-deploy/ember-cli-deploy/blob/bd7b08d1084921193042787ce27570a00dafd5aa/lib/models/plugin-registry.js#L30-L31).

This means that if another plugin wants to modify the targets, but gets loaded _after_ ember-cli-deploy-compress, its settings will have no effect for ember-cli-deploy-compress. Even worse, if the `config/targets.js` depends on some environment variables that are set by a deploy-plugin, addon or in `ember-cli-build.js` (major anti-pattern, I know, but it happens), the browser targets will have "materialized" the moment they are accessed by ember-cli-deploy-compress. Any later ENV setup that would have influenced the targets will thus not take effect _globally_.

This PR delays the access to `this.project.targets` as late as possible and moves it to `willUpload`. The tests have been updated accordingly and improved by not mocking `canUseBrotli` directly (_don't mock your test subject!_ 👨‍🏫😄), but instead mocking the actual browser targets.