### PR TITLE
Use Node's native brotli support if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@
 language: node_js
 node_js:
   - "8"
-
-sudo: false
-dist: trusty
+  - "12"
 
 cache:
   yarn: true

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var RSVP      = require('rsvp');
 var fs        = require('fs');
 var path      = require('path');
+var zlib      = require('zlib');
 var minimatch = require('minimatch');
 var caniuse   = require('caniuse-api');
 var RSVP      = require('rsvp')
@@ -134,6 +135,15 @@ module.exports = {
       },
 
       brotliCompressor() {
+        // Use native brotli support on Node >= 11
+        if (zlib.createBrotliCompress) {
+          var brotliOptions = {};
+
+          brotliOptions[zlib.constants.BROTLI_PARAM_QUALITY] = 11;
+
+          return zlib.createBrotliCompress({ params: brotliOptions });
+        }
+
         return require('iltorb').compressStream({ quality: 11 });
       },
 


### PR DESCRIPTION
On Node >=11, brotli support is built into the runtime itself. This patch makes
the library leverage this support if it is available, and updates the CI config
to test on Node 12 LTS as well.